### PR TITLE
Implement feed screen spacing and press effect

### DIFF
--- a/jarvis-fashion-ai/src/components/FeatureCard.tsx
+++ b/jarvis-fashion-ai/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { TouchableOpacity, Image, View, Text, ImageSourcePropType } from 'react-native';
+import React, { useRef } from 'react';
+import { Animated, Easing, TouchableOpacity, Image, View, ImageSourcePropType } from 'react-native';
 import styled from 'styled-components/native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import theme from '../theme';
@@ -11,11 +11,16 @@ interface FeatureCardProps {
   imageUrl?: ImageSourcePropType;
   icon?: string; // Icon name for MaterialCommunityIcons
   onPress: () => void;
+  isFirst?: boolean;
 }
 
-const CardContainer = styled.TouchableOpacity`
+const CardContainer = styled.TouchableOpacity<{ isFirst?: boolean }>`
   height: 120px;
-  margin: 0 ${({ theme }) => theme.spacing.s4}px ${({ theme }) => theme.spacing.s4}px;
+  margin-top: ${({ isFirst, theme }) =>
+    isFirst ? theme.spacing.s5 : 0}px;
+  margin-right: ${({ theme }) => theme.spacing.s4}px;
+  margin-bottom: ${({ theme }) => theme.spacing.s4}px;
+  margin-left: ${({ theme }) => theme.spacing.s4}px;
   border-radius: ${({ theme }) => theme.radii.card}px;
   background-color: ${({ theme }) => theme.colors.background};
   flex-direction: row;
@@ -65,14 +70,41 @@ const CardRightIcon = styled.View`
   height: 24px;
 `;
 
-const FeatureCard = ({ id, title, subtitle, imageUrl, icon, onPress }: FeatureCardProps) => {
+const AnimatedTouchable = Animated.createAnimatedComponent(TouchableOpacity);
+
+const FeatureCard = ({ id, title, subtitle, imageUrl, icon, onPress, isFirst }: FeatureCardProps) => {
+  const scaleAnim = useRef(new Animated.Value(1)).current;
+
+  const handlePressIn = () => {
+    Animated.timing(scaleAnim, {
+      toValue: 0.97,
+      duration: 120,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.timing(scaleAnim, {
+      toValue: 1,
+      duration: 120,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
+    }).start();
+  };
+
   return (
-    <CardContainer 
-      activeOpacity={0.97}
+    <CardContainer
+      as={AnimatedTouchable}
+      style={{ transform: [{ scale: scaleAnim }] }}
+      activeOpacity={1}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
       onPress={onPress}
       accessible={true}
       accessibilityLabel={`${title}. ${subtitle}. Button.`}
       accessibilityRole="button"
+      isFirst={isFirst}
     >
       {imageUrl ? (
         <CardImage source={imageUrl} />

--- a/jarvis-fashion-ai/src/screens/Feed/FeedScreen.tsx
+++ b/jarvis-fashion-ai/src/screens/Feed/FeedScreen.tsx
@@ -76,7 +76,7 @@ export default function FeedScreen() {
           Hello, Jane!
         </GreetingHeader>
 
-        {featureCards.map((card) => (
+        {featureCards.map((card, index) => (
           <FeatureCard
             key={card.id}
             id={card.id}
@@ -84,6 +84,7 @@ export default function FeedScreen() {
             subtitle={card.subtitle}
             icon={card.icon}
             onPress={() => handleFeatureCardPress(card.navigateTo)}
+            isFirst={index === 0}
           />
         ))}
 


### PR DESCRIPTION
## Summary
- refine FeatureCard spacing
- add animated press effect to feature cards
- space first card away from greeting header

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca4d564883339a680af44ed74eaa